### PR TITLE
use latest tag for sensor install

### DIFF
--- a/docs/beta/api-observability/common-tasks/sensor/sensor-configuration.mdx
+++ b/docs/beta/api-observability/common-tasks/sensor/sensor-configuration.mdx
@@ -163,7 +163,7 @@ sudo docker run --restart unless-stopped \
   -v /sys/kernel/debug:/sys/kernel/debug -v /proc:/host/proc \
   -v $PWD/config.yml:/home/levo/config.yml:ro \
   --privileged --detach \
-  levoai/ebpf_sensor:stable -f /home/levo/config.yml --default-service-name <'Application Name' chosen earlier>
+  levoai/ebpf_sensor:latest -f /home/levo/config.yml --default-service-name <'Application Name' chosen earlier>
 ```
 Please check the Sensor logs to ensure the configuration file does not have any syntax errors, and the Sensor is running with the applied configuration.
 

--- a/docs/beta/api-observability/common-tasks/sensor/sensor-mgmt.md
+++ b/docs/beta/api-observability/common-tasks/sensor/sensor-mgmt.md
@@ -61,7 +61,7 @@ sudo docker logs <container id from docker ps step above>
 - Uninstall Sensor
 - Pull new Sensor image
 ```bash
-docker pull levoai/ebpf_sensor:stable
+docker pull levoai/ebpf_sensor:latest
 ```
 - Reinstall Sensor
 

--- a/docs/beta/api-observability/install-guide/install-sensor.md
+++ b/docs/beta/api-observability/install-guide/install-sensor.md
@@ -108,7 +108,7 @@ Please proceed to the next step, if there are no errors.
 sudo docker run --restart unless-stopped \
   -e OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<hostname|IP:port> \
   -v /sys/kernel/debug:/sys/kernel/debug -v /proc:/host/proc \
-  --privileged --detach levoai/ebpf_sensor:stable \
+  --privileged --detach levoai/ebpf_sensor:latest \
   --default-service-name <'Application Name' chosen earlier>
 ```
 


### PR DESCRIPTION
Use latest tag for sensor.

@buchi-busireddy @VamsiNerella Need to make sure our builds are generating latest tags. Maybe they already are. Just wanted to confirm.