### PR TITLE
Update satellite's minimum url threshold env variable

### DIFF
--- a/docs/beta/api-observability/common-tasks/satellite/satellite-mgmt.mdx
+++ b/docs/beta/api-observability/common-tasks/satellite/satellite-mgmt.mdx
@@ -18,13 +18,11 @@ sidebar_position: 1
 ```bash
 # Setup environment variables
 export LEVOAI_AUTH_KEY=<'Authorization Key' from the original installation> 
-export APP_NAME=<'Application Name' chosen during installation>
 
 # Update helm repo and upgrade installation
 helm repo update
 
 helm upgrade -n levoai \
-  --set global.levoai.app_name=$APP_NAME \
   --set global.levoai_config_override.onprem-api.refresh-token=$LEVOAI_AUTH_KEY \
   levoai-satellite levoai/levoai-satellite
 ```
@@ -52,14 +50,12 @@ For example, to set this to 3:
 ```bash
 # Setup environment variables
 export LEVOAI_AUTH_KEY=<'Authorization Key' from the original installation>
-export APP_NAME=<'Application Name' chosen during installation>
 export LEVOAI_MIN_URLS_PER_PATTERN=3
 
 # Update helm repo and upgrade installation
 helm repo update
 
 helm upgrade -n levoai \
-  --set global.levoai.app_name=$APP_NAME \
   --set global.levoai_config_override.onprem-api.refresh-token=$LEVOAI_AUTH_KEY \
   --set global.levoai_config_override.min_urls_required_per_pattern=$LEVOAI_MIN_URLS_PER_PATTERN \
   levoai-satellite levoai/levoai-satellite

--- a/docs/beta/api-observability/common-tasks/satellite/satellite-mgmt.mdx
+++ b/docs/beta/api-observability/common-tasks/satellite/satellite-mgmt.mdx
@@ -39,6 +39,31 @@ helm uninstall levoai-satellite -n levoai
 - Uninstall the Satellite.
 - Reinstall the Satellite with the new `Authorization Key`.
 
+
+### Change the `minimum number of URLs` that the satellite needs to observe to detect an API endpoint.
+To detect an API endpoint, Satellite waits for at least '10' URLs to match that endpoint URL pattern.
+This number may cause delays in detecting API endpoints when there is not enough load.
+
+If you want to change this number to suit your environment:
+- Export an environment variable 'LEVOAI_MIN_URLS_PER_PATTERN', and
+- Restart the Satellite with 'min_urls_required_per_pattern' helm config override option
+
+For example, to set this to 3:
+```bash
+# Setup environment variables
+export LEVOAI_AUTH_KEY=<'Authorization Key' from the original installation>
+export APP_NAME=<'Application Name' chosen during installation>
+export LEVOAI_MIN_URLS_PER_PATTERN=3
+# Update helm repo and upgrade installation
+helm repo update
+
+helm upgrade -n levoai \
+  --set global.levoai.app_name=$APP_NAME \
+  --set global.levoai_config_override.onprem-api.refresh-token=$LEVOAI_AUTH_KEY \
+  --set global.levoai_config_override.min_urls_required_per_pattern=$LEVOAI_MIN_URLS_PER_PATTERN \
+  levoai-satellite levoai/levoai-satellite
+```
+
 ### List Satellite's pods
 ```bash
 kubectl -n levoai get pods | grep -E '^levoai-collector|^levoai-rabbitmq|^levoai-satellite|^levoai-tagger'
@@ -78,6 +103,18 @@ docker compose down --remove-orphans -v
 ### Upgrade the Satellite
 1. [Uninstall](#uninstall-the-satellite) the Satellite
 2. [Reinstall](../../install-guide/install-satellite.mdx) the Satellite. The install always *pulls* the latest Docker images for the Satellite.
+
+
+### Change the `minimum number of URLs` that the satellite needs to observe to detect an API endpoint.
+To detect an API endpoint, Satellite waits for at least '10' URLs to match that endpoint URL pattern.
+This number may cause delays in detecting API endpoints when there is not enough load.
+
+If you want to change this number to suit your environment:
+ - export an environment variable 'LEVOAI_MIN_URLS_PER_PATTERN' - for example :
+      `export LEVOAI_MIN_URLS_PER_PATTERN=3`
+
+ - Reinstall the Satellite to pickup the new configuration
+
 
 ### List Satellite's containers
 ```bash

--- a/docs/beta/api-observability/common-tasks/satellite/satellite-mgmt.mdx
+++ b/docs/beta/api-observability/common-tasks/satellite/satellite-mgmt.mdx
@@ -45,7 +45,7 @@ To detect an API endpoint, Satellite waits for at least '10' URLs to match that 
 This number may cause delays in detecting API endpoints when there is not enough load.
 
 If you want to change this number to suit your environment:
-- Export an environment variable 'LEVOAI_MIN_URLS_PER_PATTERN', and
+- Export an environment variable `LEVOAI_MIN_URLS_PER_PATTERN`, and
 - Restart the Satellite with 'min_urls_required_per_pattern' helm config override option
 
 For example, to set this to 3:
@@ -54,6 +54,7 @@ For example, to set this to 3:
 export LEVOAI_AUTH_KEY=<'Authorization Key' from the original installation>
 export APP_NAME=<'Application Name' chosen during installation>
 export LEVOAI_MIN_URLS_PER_PATTERN=3
+
 # Update helm repo and upgrade installation
 helm repo update
 
@@ -110,7 +111,7 @@ To detect an API endpoint, Satellite waits for at least '10' URLs to match that 
 This number may cause delays in detecting API endpoints when there is not enough load.
 
 If you want to change this number to suit your environment:
- - export an environment variable 'LEVOAI_MIN_URLS_PER_PATTERN' - for example :
+ - export the environment variable `LEVOAI_MIN_URLS_PER_PATTERN` - for example :
       `export LEVOAI_MIN_URLS_PER_PATTERN=3`
 
  - Reinstall the Satellite to pickup the new configuration

--- a/static/artifacts/satellite/docker-compose.yml
+++ b/static/artifacts/satellite/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       LEVOAI_MODE: docker-compose
       LEVOAI_LOG_LEVEL: ${LEVOAI_LOG_LEVEL:-INFO}
       PI_DETECTOR_DATA_DIR: /opt/levoai/datasets/
-      LEVOAI_CONF_OVERRIDES: '{"onprem-api": {"url": "${LEVOAI_BASE_URL:-https://api.levo.ai}", "refresh-token": "${LEVOAI_AUTH_KEY}", "org-id": "${LEVOAI_ORG_ID:-}", "org-prefix": "${LEVOAI_ORG_PREFIX:-}"}, "tagger_batch_interval_minutes":1}'
+      LEVOAI_CONF_OVERRIDES: '{"onprem-api": {"url": "${LEVOAI_BASE_URL:-https://api.levo.ai}", "refresh-token": "${LEVOAI_AUTH_KEY}", "org-id": "${LEVOAI_ORG_ID:-}", "org-prefix": "${LEVOAI_ORG_PREFIX:-}"}, "min_urls_required_per_pattern": "${LEVOAI_MIN_URLS_PER_PATTERN:-10}", "tagger_batch_interval_minutes":1}'
       LAYER9_PROTOSET_DISABLED: 'yes'
     depends_on:
       levoai-rabbitmq:

--- a/static/artifacts/satellite/proxy-docker-compose.yml
+++ b/static/artifacts/satellite/proxy-docker-compose.yml
@@ -47,7 +47,7 @@ services:
       LEVOAI_MODE: docker-compose
       LEVOAI_LOG_LEVEL: ${LEVOAI_LOG_LEVEL:-INFO}
       PI_DETECTOR_DATA_DIR: /opt/levoai/datasets/
-      LEVOAI_CONF_OVERRIDES: '{"onprem-api": {"url": "${LEVOAI_BASE_URL:-https://api.levo.ai}", "refresh-token": "${LEVOAI_AUTH_KEY}", "org-id": "${LEVOAI_ORG_ID:-}", "org-prefix": "${LEVOAI_ORG_PREFIX:-}"}, "tagger_batch_interval_minutes":1}'
+      LEVOAI_CONF_OVERRIDES: '{"onprem-api": {"url": "${LEVOAI_BASE_URL:-https://api.levo.ai}", "refresh-token": "${LEVOAI_AUTH_KEY}", "org-id": "${LEVOAI_ORG_ID:-}", "org-prefix": "${LEVOAI_ORG_PREFIX:-}"}, "min_urls_required_per_pattern": "${LEVOAI_MIN_URLS_PER_PATTERN:-10}", "tagger_batch_interval_minutes":1}'
       LAYER9_PROTOSET_DISABLED: 'yes'
     depends_on:
       levoai-rabbitmq:


### PR DESCRIPTION
    The ENV variable `LEVOAI_MIN_URLS_PER_PATTERN` can be used to tweak the minimum number of URLs to match a particular API endpoint pattern before declaring that pattern as a valid endpoint.

Changes:
   - Updated `docker-compose.yml `and `proxy-docker-compose.yml `with new environment variable `LEVOAI_MIN_URLS_PER_PATTERN`.
   
   - Also updated the docs with instructions on how to set this.
