### PR TITLE
Document upgrade process for Satellite version `0.2.522`

### DIFF
--- a/docs/install-satellite/satellite-kubernetes.md
+++ b/docs/install-satellite/satellite-kubernetes.md
@@ -116,6 +116,17 @@ Please proceed to [install Traffic Capture Sensors](/install-traffic-capture-sen
 ## Satellite Lifecycle Management
 
 ### Upgrade Satellite
+
+:::note
+
+Please check the following table for notes on certain versions to ensure a smooth upgrade process.
+
+| Version | Notes |
+| ------- | ----- |
+| `0.2.522` and newer | Persistence is disabled for the RabbitMQ StatefulSet by default. On fresh installations, nothing needs to be done. However, when upgrading from versions prior to `0.2.522`, you will need to manually delete the StatefulSet and PersistentVolumeClaim resources before upgrading. You can do this with the following commands: <pre>kubectl delete statefulset levoai-rabbitmq -n levoai<br/>kubectl delete pvc data-levoai-rabbitmq-0 -n levoai</pre> |
+
+:::
+
 ```bash
 # Setup environment variables
 export LEVOAI_AUTH_KEY=<'Authorization Key' from the original installation> 


### PR DESCRIPTION
RabbitMQ persistence is disabled by default in Kubernetes installation starting with version `0.2.522`.

Add a table with two columns - version and notes - to document specific steps needed to upgrade to this version of the Satellite in Kubernetes.

![image](https://github.com/levoai/docs/assets/16446369/9e310880-52e6-4137-9e2a-6ddf5d1bf0f5)
